### PR TITLE
Added negation of velocity and position values depending on inverted encoder setting

### DIFF
--- a/parameter/edu_drive_edu_bot.yaml
+++ b/parameter/edu_drive_edu_bot.yaml
@@ -23,10 +23,10 @@
       invertEnc: 1
       drive0: #front right
         channel: 0
-        kinematics: [20.0, 20.0, 6.1]
+        kinematics: [-20.0, -20.0, -6.1]
       drive1: #rear right
         channel: 1
-        kinematics: [20.0, -20.0, 6.1]
+        kinematics: [-20.0, 20.0, -6.1]
 
     controller1:
       canID: 1
@@ -36,7 +36,7 @@
       invertEnc: 1
       drive0: #front left
         channel: 0
-        kinematics: [-20.0, 20.0, 6.1]
+        kinematics: [20.0, -20.0, -6.1]
       drive1: #rear left
         channel: 1
-        kinematics: [-20.0, -20.0, 6.1]
+        kinematics: [20.0, 20.0, -6.1]

--- a/src/MotorController.cpp
+++ b/src/MotorController.cpp
@@ -39,7 +39,7 @@ MotorController::MotorController(SocketCAN* can, ControllerParams params, bool v
       std::cout << "       channel: " << _params.motorParams[i].channel << std::endl;
       std::cout << "       kinematics: ";
       for(unsigned int j=0; j<_params.motorParams[i].kinematics.size(); j++)
-        std::cout << _params.motorParams[i].kinematics[j] << " ";
+        std::cout << _params.motorParams[i].kinematics[j] << " ";      
       std::cout << std::endl;
     }
 
@@ -330,6 +330,12 @@ bool MotorController::setPWM(int pwm[2])
   if(vel1<-100) vel1 = -100;
   if(vel2>100)  vel2 = 100;
   if(vel2<-100) vel2 = -100;
+
+   if(_params.invertEnc){
+    vel1 = -vel1;
+    vel2 = -vel2;
+   }
+
   _cf.data[0] = CMD_MOTOR_SETPWM;
   _cf.data[1] = (char)vel1;
   _cf.data[2] = (char)vel2;
@@ -343,6 +349,12 @@ bool MotorController::setRPM(float rpm[2])
 
   int vel1 = (int)(rpm[0]*100.f);
   int vel2 = (int)(rpm[1]*100.f);
+
+  if(_params.invertEnc){
+    vel1 = -vel1;
+    vel2 = -vel2;
+   }
+
   _cf.data[0] = CMD_MOTOR_SETRPM;
   _cf.data[1] = (char)(vel1 >> 8) & 0xFF;
   _cf.data[2] = (char)(vel1)      & 0xFF;
@@ -448,6 +460,11 @@ void MotorController::notify(struct can_frame* frame)
       _rpm[1] = ((float)val2) / 100.f;
       _pos[0] = 0.f;
       _pos[1] = 0.f;
+
+      if(_params.invertEnc){
+        _rpm[0] = - _rpm[0];
+        _rpm[1] = - _rpm[1];
+      }
     }
     else if(frame->data[0] == RESPONSE_MOTOR_POS)
     {
@@ -455,6 +472,11 @@ void MotorController::notify(struct can_frame* frame)
       _rpm[1] = 0.f;
       _pos[0] = (frame->data[1] | (frame->data[2] << 8));
       _pos[1] = (frame->data[3] | (frame->data[4] << 8));
+
+      if(_params.invertEnc){
+        _pos[0] = - _pos[0];
+        _pos[1] = - _pos[1];
+      }
     }
     _enabled = (frame->data[5] != 0);
     if(_verbosity)


### PR DESCRIPTION
If the _invertEnc_ parameter is set, the rpm and position values sent to- and received from the motorcontroller-boards now get inverted. This allows the kinematic-parameters to be calculated as described in the README file without having to invert them manually.

This also solves the apparent negation of the wheel speeds published by the node, in case the kinematic parameters are negated by hand. The published wheel speed are now in line with the proper robot ksys.

Only verified on a robot where invertEnc is set (=1) for all motorconrollers. Not verified on a robot where invertEnc is not set (=0).