### PR TITLE
make motor controllers individually configurable

### DIFF
--- a/src/edu_drive_node.cpp
+++ b/src/edu_drive_node.cpp
@@ -67,27 +67,34 @@ int main(int argc, char *argv[])
    {
       edu::ControllerParams cp;
 
-      cp.frequencyScale = frequencyScale;
-      cp.inputWeight    = inputWeight;
-      cp.maxPulseWidth  = maxPulseWidth;
-      cp.timeout        = timeout;
-      cp.kp             = kp;
-      cp.ki             = ki;
-      cp.kd             = kd;
-      cp.antiWindup     = antiWindup;
-      
       std::string controllerID = std::string("controller") + std::to_string(c);
       edu_drive->declare_parameter(controllerID + std::string(".canID"), 0);
       edu_drive->declare_parameter(controllerID + std::string(".gearRatio"), 0.f);
       edu_drive->declare_parameter(controllerID + std::string(".encoderRatio"), 0.f);
       edu_drive->declare_parameter(controllerID + std::string(".rpmMax"), 0.f);
       edu_drive->declare_parameter(controllerID + std::string(".invertEnc"), 0);
+      edu_drive->declare_parameter(controllerID + std::string(".frequencyScale"), frequencyScale);
+      edu_drive->declare_parameter(controllerID + std::string(".inputWeight"), inputWeight);
+      edu_drive->declare_parameter(controllerID + std::string(".maxPulseWidth"), maxPulseWidth);
+      edu_drive->declare_parameter(controllerID + std::string(".timeout"), timeout);
+      edu_drive->declare_parameter(controllerID + std::string(".kp"), kp);
+      edu_drive->declare_parameter(controllerID + std::string(".ki"), ki);
+      edu_drive->declare_parameter(controllerID + std::string(".kd"), kd);
+      edu_drive->declare_parameter(controllerID + std::string(".antiWindup"), antiWindup);
 
       cp.canID        = edu_drive->get_parameter(controllerID + std::string(".canID")).as_int();
       cp.gearRatio    = edu_drive->get_parameter(controllerID + std::string(".gearRatio")).as_double();
       cp.encoderRatio = edu_drive->get_parameter(controllerID + std::string(".encoderRatio")).as_double();
       cp.rpmMax       = edu_drive->get_parameter(controllerID + std::string(".rpmMax")).as_double();
       cp.invertEnc    = edu_drive->get_parameter(controllerID + std::string(".invertEnc")).as_int();
+      cp.frequencyScale=edu_drive->get_parameter(controllerID + std::string(".frequencyScale")).as_int();
+      cp.inputWeight  = edu_drive->get_parameter(controllerID + std::string(".inputWeight")).as_double();
+      cp.maxPulseWidth= edu_drive->get_parameter(controllerID + std::string(".maxPulseWidth")).as_int();
+      cp.timeout      = edu_drive->get_parameter(controllerID + std::string(".timeout")).as_int();
+      cp.kp           = edu_drive->get_parameter(controllerID + std::string(".kp")).as_double();
+      cp.ki           = edu_drive->get_parameter(controllerID + std::string(".ki")).as_double();
+      cp.kd           = edu_drive->get_parameter(controllerID + std::string(".kd")).as_double();
+      cp.antiWindup   = edu_drive->get_parameter(controllerID + std::string(".antiWindup")).as_int();
 
       cp.responseMode   = (responseMode==0 ? edu::CAN_RESPONSE_RPM : edu::CAN_RESPONSE_POS);
 


### PR DESCRIPTION
> - allows setting parameters such as PID on a per-controller basis
> - uses parameters declared globally when no individual parameters are given

Needed when individual motors require different parameters